### PR TITLE
Fixes exception when request is None

### DIFF
--- a/django_auth_lti/patch_reverse.py
+++ b/django_auth_lti/patch_reverse.py
@@ -25,13 +25,20 @@ def reverse(*args, **kwargs):
     exclude_resource_link_id = kwargs.pop('exclude_resource_link_id', False)
 
     url = django_reverse(*args, **kwargs)
-    resource_link_id = request.LTI.get('resource_link_id')
-    if not exclude_resource_link_id and resource_link_id is not None:
+
+    if request:
+        resource_link_id = request.get('LTI', {}).get('resource_link_id')
+    else:
+        resource_link_id = None
+
+    if not exclude_resource_link_id and resource_link_id:
         # Append resource_link_id query param if exclude_resource_link_id kwarg was not passed or is False
         parsed = urlparse(url)
         query = parse_qs(parsed.query)
         if 'resource_link_id' not in query.keys():
-            query['resource_link_id'] = request.LTI.get('resource_link_id')
+            if resource_link_id:
+                query['resource_link_id'] = resource_link_id
+
             url = urlunparse(
                 (parsed.scheme, parsed.netloc, parsed.path, parsed.params, urlencode(query), parsed.fragment)
             )


### PR DESCRIPTION
I hit a bug with Debug = True and the Django Debug Toolbar enabled, where this code couldn't handle request returned from the local thread being None.
